### PR TITLE
Fix canonical site domain so og:image works on LinkedIn

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ import rehypeExternalLinks from 'rehype-external-links'
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://justinbarias.github.io',
+  site: 'https://justinbarias.io',
   integrations: [mdx(), svelte()],
   markdown: {
     shikiConfig: {

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+justinbarias.io


### PR DESCRIPTION
## Problem

Social preview cards rendered on Facebook and Twitter/X but **not LinkedIn**.

**Root cause:** `astro.config.mjs` declared `site: 'https://justinbarias.github.io'`, but the site is served from the custom domain `justinbarias.io`. The github.io host issues a cross-domain `301` redirect (and downgrades to `http://`):

```
https://justinbarias.github.io/og/the-token-reckoning.png
  → 301 → http://justinbarias.io/og/the-token-reckoning.png
```

Facebook and Twitter follow that redirect on `og:image`; **LinkedIn does not**, so it dropped the image. Every absolute URL the site emitted (og:image, og:url, canonical, RSS, sitemap) pointed at the redirecting host.

## Fix

- Point `site` at the real domain → `https://justinbarias.io`. Absolute URLs now resolve directly (HTTPS, `200`, no redirect). Verified `https://justinbarias.io/og/<slug>.png` returns `200 image/png`.
- Add `public/CNAME` (`justinbarias.io`) so the custom domain ships in the deploy artifact and can't silently reset to the github.io host — which would reintroduce this exact bug.

## Verified locally
- `og:image` → `https://justinbarias.io/og/the-token-reckoning.png`
- `og:url` → `https://justinbarias.io/blog/the-token-reckoning`
- homepage `og:image` → `https://justinbarias.io/og/default.png`

After deploy, re-scrape via LinkedIn Post Inspector to bust their cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)